### PR TITLE
IIP1

### DIFF
--- a/src/HoneyQueen.sol
+++ b/src/HoneyQueen.sol
@@ -30,7 +30,7 @@ contract HoneyQueen is Ownable {
     uint256 public fees = 200; // in bps
     IBGT public constant BGT = IBGT(0xbDa130737BDd9618301681329bF2e46A016ff9Ad);
     // prettier-ignore
-    mapping(address LPToken => address stakingContract) public LPTokenToStakingContract;
+    mapping(address stakingContract => bool allowed) public isStakingContractAllowed;
     // prettier-ignore
     mapping(bytes32 fromCodeHash => mapping(bytes32 toCodeHash => bool isEnabled)) public isMigrationEnabled;
 
@@ -44,11 +44,11 @@ contract HoneyQueen is Ownable {
     /*###############################################################
                             OWNER LOGIC
     ###############################################################*/
-    function setLPTokenToStakingContract(
-        address _LPToken,
-        address _stakingContract
+    function setIsStakingContractAllowed(
+        address _stakingContract,
+        bool _isAllowed
     ) external onlyOwner {
-        LPTokenToStakingContract[_LPToken] = _stakingContract;
+        isStakingContractAllowed[_stakingContract] = _isAllowed;
     }
     // prettier-ignore
     function setMigrationFlag(

--- a/src/HoneyQueen.sol
+++ b/src/HoneyQueen.sol
@@ -31,6 +31,8 @@ contract HoneyQueen is Ownable {
     IBGT public constant BGT = IBGT(0xbDa130737BDd9618301681329bF2e46A016ff9Ad);
     // prettier-ignore
     mapping(address stakingContract => bool allowed) public isStakingContractAllowed;
+    // this is for cases where gauges give you a NFT to represent your staking position
+    mapping(address token => bool blocked) public isTokenBlocked;
     // prettier-ignore
     mapping(bytes32 fromCodeHash => mapping(bytes32 toCodeHash => bool isEnabled)) public isMigrationEnabled;
 
@@ -50,6 +52,14 @@ contract HoneyQueen is Ownable {
     ) external onlyOwner {
         isStakingContractAllowed[_stakingContract] = _isAllowed;
     }
+
+    function setIsTokenBlocked(
+        address _token,
+        bool _isBlocked
+    ) external onlyOwner {
+        isTokenBlocked[_token] = _isBlocked;
+    }
+
     // prettier-ignore
     function setMigrationFlag(
         bool _isMigrationEnabled,

--- a/src/utils/IStakingContract.sol
+++ b/src/utils/IStakingContract.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.8.23;
+
+interface IStakingContract {
+    event Staked(address indexed staker, uint256 amount);
+    function stake(uint256 amount) external;
+    function withdraw(uint256 amount) external;
+    function getReward(address account) external;
+    //function balanceOf(address account) external view returns (uint256);
+    function exit() external;
+}

--- a/src/utils/TokenReceiver.sol
+++ b/src/utils/TokenReceiver.sol
@@ -17,7 +17,7 @@ contract TokenReceiver {
         uint256[] calldata,
         uint256[] calldata,
         bytes calldata
-    ) external returns (bytes4) {
+    ) external pure returns (bytes4) {
         return 0xbc197c81;
     }
 
@@ -26,7 +26,7 @@ contract TokenReceiver {
         address,
         uint256,
         bytes calldata
-    ) external returns (bytes4) {
+    ) external pure returns (bytes4) {
         return 0x150b7a02;
     }
 }

--- a/test/mocks/FakeGauge.sol
+++ b/test/mocks/FakeGauge.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import {ERC20} from "solady/tokens/ERC20.sol";
+
+/*
+    Follow same ABI as BGT Station gauges.
+*/
+contract FakeGauge {
+    event Staked(address indexed staker, uint256 amount);
+
+    address public token;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function stake(uint256 amount) external {
+        ERC20(token).transferFrom(msg.sender, address(this), amount);
+        emit Staked(msg.sender, amount);
+    }
+
+    function withdraw(uint256 amount) external {
+        ERC20(token).transfer(msg.sender, amount);
+    }
+
+    function getReward(address account) external {}
+    function exit() external {}
+}

--- a/test/mocks/GaugeAsNFT.sol
+++ b/test/mocks/GaugeAsNFT.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import {ERC20} from "solady/tokens/ERC20.sol";
+import {ERC721} from "solady/tokens/ERC721.sol";
+
+/*
+    Follow same ABI as BGT Station gauges.
+    Mints a NFT to represent the position of the user.
+*/
+contract GaugeAsNFT is ERC721 {
+    event Staked(address indexed staker, uint256 amount);
+
+    address public token;
+    mapping(uint256 id => uint256 amount) public idToAmountStaked;
+    uint256 count;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function name() public view override returns (string memory) {
+        return "GaugeAsNFT";
+    }
+
+    function symbol() public view override returns (string memory) {
+        return "GaugeAsNFT";
+    }
+
+    function tokenURI(uint256 id) public view override returns (string memory) {
+        return "";
+    }
+
+    function stake(uint256 amount) external {
+        ERC20(token).transferFrom(msg.sender, address(this), amount);
+        uint256 tokenId = count++;
+        _mint(msg.sender, tokenId);
+        idToAmountStaked[tokenId] = amount;
+        emit Staked(msg.sender, amount);
+    }
+
+    function withdraw(uint256 tokenId) external {
+        // prettier-ignore
+        require(ownerOf(tokenId) == msg.sender, "GaugeAsNFT: caller is not owner");
+        uint256 amount = idToAmountStaked[tokenId];
+        _burn(tokenId);
+        ERC20(token).transfer(msg.sender, amount);
+    }
+
+    function getReward(address account) external {}
+    function exit() external {}
+}


### PR DESCRIPTION
**Interpol Improvement Push 1**

- Allow multiple deposits for a given LP Token
- Allow staking into different gauges for a given LP Token
- Separate depositing from staking
- Handle the edge cases of NFTs or ERC20 that represent position in the gauge

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the staking and token handling logic in the `HoneyVault` contract. 

### Detailed summary
- Updated functions in `TokenReceiver.sol` and `IStakingContract.sol` to `external pure returns (bytes4)`
- Added `isStakingContractAllowed` mapping in `HoneyQueen.sol`
- Added `isTokenBlocked` mapping in `HoneyQueen.sol`
- Added `GaugeAsNFT` contract with NFT minting functionality
- Updated tests in `HoneyVault.t.sol` with new staking and token handling scenarios

> The following files were skipped due to too many changes: `src/HoneyVault.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->