### PR TITLE
Calldata

### DIFF
--- a/src/HoneyQueen.sol
+++ b/src/HoneyQueen.sol
@@ -31,6 +31,8 @@ contract HoneyQueen is Ownable {
     IBGT public constant BGT = IBGT(0xbDa130737BDd9618301681329bF2e46A016ff9Ad);
     // prettier-ignore
     mapping(address stakingContract => bool allowed) public isStakingContractAllowed;
+    mapping(bytes4 selector => mapping(string action => mapping(address stakingContract => bool allowed)))
+        public isSelectorAllowed;
     // this is for cases where gauges give you a NFT to represent your staking position
     mapping(address token => bool blocked) public isTokenBlocked;
     // prettier-ignore
@@ -51,6 +53,15 @@ contract HoneyQueen is Ownable {
         bool _isAllowed
     ) external onlyOwner {
         isStakingContractAllowed[_stakingContract] = _isAllowed;
+    }
+
+    function setIsSelectorAllowed(
+        bytes4 _selector,
+        string memory _action,
+        address _stakingContract,
+        bool _isAllowed
+    ) external onlyOwner {
+        isSelectorAllowed[_selector][_action][_stakingContract] = _isAllowed;
     }
 
     function setIsTokenBlocked(

--- a/src/HoneyVault.sol
+++ b/src/HoneyVault.sol
@@ -28,6 +28,10 @@ contract HoneyVault is TokenReceiver, Ownable {
     error TokenBlocked();
     error CannotBeLPToken();
     error HasToBeLPToken();
+    error StakeFailed();
+    error UnstakeFailed();
+    error SelectorNotAllowed();
+    error ClaimRewardsFailed();
     /*###############################################################
                             EVENTS
     ###############################################################*/
@@ -68,6 +72,26 @@ contract HoneyVault is TokenReceiver, Ownable {
         if (HONEY_QUEEN.isTokenBlocked(_token)) revert TokenBlocked();
         _;
     }
+
+    modifier onlyAllowedSelector(
+        address _stakingContract,
+        string memory action,
+        bytes memory data
+    ) {
+        bytes4 selector;
+        assembly {
+            selector := mload(add(data, 32))
+        }
+        if (!HONEY_QUEEN.isSelectorAllowed(selector, action, _stakingContract))
+            revert SelectorNotAllowed();
+        _;
+    }
+
+    modifier onlyAllowedStakingContract(address _stakingContract) {
+        if (!HONEY_QUEEN.isStakingContractAllowed(_stakingContract))
+            revert StakingContractNotAllowed();
+        _;
+    }
     /*###############################################################
                             INITIALIZER
     ###############################################################*/
@@ -88,13 +112,18 @@ contract HoneyVault is TokenReceiver, Ownable {
     function stake(
         address _LPToken,
         address _stakingContract,
-        uint256 _amount
-    ) external onlyOwner {
-        if (!HONEY_QUEEN.isStakingContractAllowed(_stakingContract))
-            revert StakingContractNotAllowed();
+        uint256 _amount,
+        bytes memory data
+    )
+        external
+        onlyOwner
+        onlyAllowedStakingContract(_stakingContract)
+        onlyAllowedSelector(_stakingContract, "stake", data)
+    {
         staked[_LPToken][_stakingContract] += _amount;
         ERC20(_LPToken).approve(address(_stakingContract), _amount);
-        IStakingContract(_stakingContract).stake(_amount);
+        (bool success, ) = _stakingContract.call(data);
+        if (!success) revert StakeFailed();
 
         emit Staked(_stakingContract, _LPToken, _amount);
     }
@@ -102,26 +131,33 @@ contract HoneyVault is TokenReceiver, Ownable {
     function unstake(
         address _LPToken,
         address _stakingContract,
-        uint256 _amount
-    ) public onlyOwner {
-        // no need to check if staking is legit
+        uint256 _amount,
+        bytes memory data
+    )
+        public
+        onlyOwner
+        onlyAllowedStakingContract(_stakingContract)
+        onlyAllowedSelector(_stakingContract, "unstake", data)
+    {
+        if (!HONEY_QUEEN.isStakingContractAllowed(_stakingContract))
+            revert StakingContractNotAllowed();
         staked[_LPToken][_stakingContract] -= _amount;
-        IStakingContract(_stakingContract).withdraw(_amount);
-        IStakingContract(_stakingContract).getReward(address(this));
+        (bool success, ) = _stakingContract.call(data);
+        if (!success) revert UnstakeFailed();
 
         emit Unstaked(_stakingContract, _LPToken, _amount);
     }
 
-    function unstakeMultiple(
-        address[] calldata _LPTokens,
-        address[] calldata _stakingContracts,
-        uint256[] calldata _amounts
-    ) external onlyOwner {
-        uint256 length = _LPTokens.length;
-        for (uint256 i; i < length; i++) {
-            unstake(_LPTokens[i], _stakingContracts[i], _amounts[i]);
-        }
-    }
+    // function unstakeMultiple(
+    //     address[] calldata _LPTokens,
+    //     address[] calldata _stakingContracts,
+    //     uint256[] calldata _amounts
+    // ) external onlyOwner {
+    //     uint256 length = _LPTokens.length;
+    //     for (uint256 i; i < length; i++) {
+    //         unstake(_LPTokens[i], _stakingContracts[i], _amounts[i]);
+    //     }
+    // }
 
     function burnBGTForBERA(uint256 _amount) external onlyOwner {
         HONEY_QUEEN.BGT().redeem(address(this), _amount);
@@ -230,9 +266,16 @@ contract HoneyVault is TokenReceiver, Ownable {
         Claims rewards, BGT, from the staking contract.
         The reward goes into the HoneyVault.
     */
-    function claimRewards(address _stakingContract) external {
-        // prettier-ignore
-        IStakingContract(_stakingContract).getReward(address(this));
+    function claimRewards(
+        address _stakingContract,
+        bytes memory data
+    )
+        external
+        onlyAllowedStakingContract(_stakingContract)
+        onlyAllowedSelector(_stakingContract, "rewards", data)
+    {
+        (bool success, ) = _stakingContract.call(data);
+        if (!success) revert ClaimRewardsFailed();
     }
 
     function clone() external returns (address) {

--- a/src/HoneyVault.sol
+++ b/src/HoneyVault.sol
@@ -139,8 +139,6 @@ contract HoneyVault is TokenReceiver, Ownable {
         onlyAllowedStakingContract(_stakingContract)
         onlyAllowedSelector(_stakingContract, "unstake", data)
     {
-        if (!HONEY_QUEEN.isStakingContractAllowed(_stakingContract))
-            revert StakingContractNotAllowed();
         staked[_LPToken][_stakingContract] -= _amount;
         (bool success, ) = _stakingContract.call(data);
         if (!success) revert UnstakeFailed();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the HoneyVault contract by adding the ability to control allowed selectors for staking actions and handling stake, unstake, and rewards functions securely.

### Detailed summary
- Added `isSelectorAllowed` mapping to control allowed selectors for staking actions
- Implemented modifiers to check for allowed selectors and staking contracts
- Updated stake, unstake, and claim rewards functions to use encoded data for selectors
- Added error handling for stake, unstake, and claim rewards failures
- Removed `unstakeMultiple` function from HoneyVault
- Added `SelectorNotAllowed`, `StakeFailed`, `UnstakeFailed`, and `ClaimRewardsFailed` error messages
- Test cases for stake, unstake, claim rewards, and prevention of cheating selector actions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->